### PR TITLE
Relax check on HLS version header

### DIFF
--- a/lib/hls/playlist/master.ex
+++ b/lib/hls/playlist/master.ex
@@ -61,7 +61,7 @@ defimpl HLS.Playlist.Unmarshaler, for: HLS.Playlist.Master do
 
   @impl true
   def load_tags(playlist, tags) do
-    [version] = Map.fetch!(tags, Tag.Version.id())
+    [version] = Map.get(tags, Tag.Version.id(), [%{value: 1}])
 
     renditions =
       tags

--- a/lib/hls/playlist/media.ex
+++ b/lib/hls/playlist/media.ex
@@ -133,7 +133,7 @@ defimpl HLS.Playlist.Unmarshaler, for: HLS.Playlist.Media do
 
   @impl true
   def load_tags(playlist, tags) do
-    [version] = Map.fetch!(tags, Tag.Version.id())
+    [version] = Map.get(tags, Tag.Version.id(), [%{value: 1}])
     [segment_duration] = Map.fetch!(tags, Tag.TargetSegmentDuration.id())
     [sequence_number] = Map.fetch!(tags, Tag.MediaSequenceNumber.id())
 


### PR DESCRIPTION
Hi, thanks for the membrane HLS and TS plugins. I have been doing some POC implementations with them and I noticed many m3u8 manifests were failing due to a missing version header. 

The spec (https://datatracker.ietf.org/doc/html/rfc8216#section-7) says that the header must be included if the manifest is not compatible with version 1. Since the version parsing is using `Map.fetch/2` it fails for manifests which do not include the header (should assume version 1).

Let me know what you think! I hope I didn't misinterpret the spec!