### PR TITLE
Fix bug when master playlist has EXT-X-MEDIA-SEQUENCE tag

### DIFF
--- a/lib/hls/playlist/tag.ex
+++ b/lib/hls/playlist/tag.ex
@@ -77,7 +77,7 @@ defmodule HLS.Playlist.Tag do
       @impl true
       def match?(line) do
         prefix = Tag.marshal_id(unquote(tag_id))
-        String.starts_with?(line, prefix)
+        line == prefix or String.starts_with?(line, prefix <> ":")
       end
 
       @impl true

--- a/test/hls/playlist_test.exs
+++ b/test/hls/playlist_test.exs
@@ -186,7 +186,7 @@ defmodule HLS.PlaylistTest do
       end)
     end
 
-    test "handels complex uri specifications" do
+    test "handles complex uri specifications" do
       content = """
       #EXTM3U
       #EXT-X-VERSION:3
@@ -235,6 +235,16 @@ defmodule HLS.PlaylistTest do
       |> Enum.each(fn {key, val} ->
         assert Map.get(rendition, key) == val, "expected #{inspect(val)} on key #{inspect(key)}"
       end)
+    end
+
+    test "ignores EXT-X-MEDIA-SEQUENCE tag" do
+      content = """
+      #EXTM3U
+      #EXT-X-MEDIA-SEQUENCE:0
+      """
+
+      manifest = Playlist.unmarshal(content, %Master{})
+      assert manifest
     end
   end
 


### PR DESCRIPTION
Right now, marshaling Master playlists fails if the file contains `EXT-X-MEDIA-SEQUENCE`.
The reason is that we check tags with `String.starts_with?/2`, which returns `true` for master `EXT-X-MEDIA` tag.

This PR implements stricter tags check with:
```elixir
line == prefix or String.starts_with?(line, prefix <> ":")
```