### PR TITLE
Add handling of discontinuity EXT flag

### DIFF
--- a/lib/hls/playlist/media.ex
+++ b/lib/hls/playlist/media.ex
@@ -127,7 +127,8 @@ defimpl HLS.Playlist.Unmarshaler, for: HLS.Playlist.Media do
       Tag.MediaSequenceNumber,
       Tag.EndList,
       Tag.Inf,
-      Tag.SegmentURI
+      Tag.SegmentURI,
+      Tag.Discontinuity
     ]
   end
 

--- a/lib/hls/playlist/tag.ex
+++ b/lib/hls/playlist/tag.ex
@@ -200,7 +200,6 @@ defmodule HLS.Playlist.Tag do
     marshaled_tag_id = marshal_id(tag_id)
     regex = Regex.compile!("#{marshaled_tag_id}:(?<target>#{match_pattern})")
     %{"target" => raw} = Regex.named_captures(regex, data)
-
     parser_fun.(raw)
   end
 

--- a/lib/hls/playlist/tag/discontinuity.ex
+++ b/lib/hls/playlist/tag/discontinuity.ex
@@ -1,0 +1,6 @@
+defmodule HLS.Playlist.Tag.Discontinuity do
+  use HLS.Playlist.Tag, id: :ext_x_discontinuity
+
+  @impl true
+  def unmarshal(_data), do: true
+end

--- a/lib/hls/segment.ex
+++ b/lib/hls/segment.ex
@@ -8,10 +8,11 @@ defmodule HLS.Segment do
           duration: float(),
           relative_sequence: pos_integer(),
           absolute_sequence: pos_integer() | nil,
-          from: pos_integer() | nil
+          from: pos_integer() | nil,
+          discontinuity: boolean()
         }
 
-  defstruct [:uri, :duration, :relative_sequence, :absolute_sequence, :from, :ref]
+  defstruct [:uri, :duration, :relative_sequence, :absolute_sequence, :from, :ref, :discontinuity]
 
   @spec from_tags([Tag.t()]) :: t()
   def from_tags(tags) do
@@ -32,11 +33,17 @@ defmodule HLS.Segment do
     duration = Enum.find(tags, fn tag -> tag.id == Tag.Inf.id() end)
     uri = Enum.find(tags, fn tag -> tag.id == Tag.SegmentURI.id() end)
 
+    discontinuity =
+      Enum.any?(tags, fn tag ->
+        tag.id == :ext_x_discontinuity
+      end)
+
     %__MODULE__{
       uri: uri.value,
       duration: duration.value,
       relative_sequence: sequence,
-      ref: make_ref()
+      ref: make_ref(),
+      discontinuity: discontinuity
     }
   end
 

--- a/test/hls/playlist_test.exs
+++ b/test/hls/playlist_test.exs
@@ -357,5 +357,32 @@ defmodule HLS.PlaylistTest do
       assert last.uri.query ==
                "t=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTc5MTYzMDEsImlhdCI6MTY1Nzg3MzEwMSwiaXNzIjoiY2RwIiwic3ViIjoiNmhReUhyUGRhRTNuL2Evc3RyZWFtXzEyODB4NzIwXzMzMDBrIiwidXNlcl9pZCI6IjMwNiIsInZpc2l0b3JfaWQiOiJiMGMyMGVkZS0wNDE2LTExZWQtYTYyMS0wYTU4YTlmZWFjMDIifQ.Fj7CADyZeoWtpaqiZLPodNHMWhlGeKjxLwpMR7lygqk"
     end
+
+    test "recognizes discontinuity tag" do
+      content = """
+      #EXTM3U
+      #EXT-X-VERSION:7
+      #EXT-X-TARGETDURATION:10
+      #EXT-X-MEDIA-SEQUENCE:0
+      #EXTINF:10.0,
+      video_segment_0_video_track.ts
+      #EXT-X-DISCONTINUITY
+      #EXTINF:2.0,
+      video_segment_1_video_track.ts
+      #EXTINF:3.0,
+      video_segment_2_video_track.ts
+      #EXT-X-ENDLIST
+      """
+
+      manifest = Playlist.unmarshal(content, %Media{})
+      segments = Media.segments(manifest)
+      first = Enum.at(segments, 0)
+      second = Enum.at(segments, 1)
+      third = Enum.at(segments, 2)
+
+      assert first.discontinuity == false
+      assert second.discontinuity == true
+      assert third.discontinuity == false
+    end
   end
 end


### PR DESCRIPTION
This PR:
* allows for reading the ext-discontinuity flag from the HLS playlist
* adds a discontinuity field to the metadata of the buffers based on whether or not there has been an ext-discontinuity flag attached to the buffer's segment