### PR TITLE
Allow FRAME-RATE to be a integer value

### DIFF
--- a/lib/hls/playlist/tag/variant_stream.ex
+++ b/lib/hls/playlist/tag/variant_stream.ex
@@ -30,7 +30,7 @@ defmodule HLS.Playlist.Tag.VariantStream do
         {:closed_captions, val}
 
       "FRAME-RATE", val ->
-        {:frame_rate, String.to_float(val)}
+        {:frame_rate, parse_float_or_int(val)}
 
       "RESOLUTION", val ->
         [width, height] =
@@ -44,5 +44,12 @@ defmodule HLS.Playlist.Tag.VariantStream do
         :skip
     end)
     |> Map.put_new(:uri, URI.parse(stream_uri))
+  end
+
+  defp parse_float_or_int(val) do
+    case Float.parse(val) do
+      {float_val, ""} -> float_val
+      :error -> String.to_integer(val)
+    end
   end
 end

--- a/test/hls/playlist_test.exs
+++ b/test/hls/playlist_test.exs
@@ -251,6 +251,33 @@ defmodule HLS.PlaylistTest do
       end)
     end
 
+    test "handles integer frame-rate values" do
+      content = """
+      #EXTM3U
+      #EXT-X-VERSION:3
+      #EXT-X-STREAM-INF:BANDWIDTH=1478400,AVERAGE-BANDWIDTH=1425600,CODECS="avc1.4d4029,mp4a.40.2",RESOLUTION=854x480,FRAME-RATE=30
+      stream_854x480.m3u8
+      """
+
+      manifest = Playlist.unmarshal(content, %Master{})
+      assert %VariantStream{} = stream = List.first(Master.variant_streams(manifest))
+
+      [
+        uri: %URI{path: "stream_854x480.m3u8"},
+        bandwidth: 1_478_400,
+        average_bandwidth: 1_425_600,
+        codecs: ["avc1.4d4029", "mp4a.40.2"],
+        resolution: {854, 480},
+        frame_rate: 30.0
+      ]
+      |> Enum.each(fn {key, val} ->
+        have = Map.get(stream, key)
+
+        assert have == val,
+               "expected #{inspect(val)} on key #{inspect(key)}, have #{inspect(have)}"
+      end)
+    end
+
     test "handels complex uri specifications" do
       content = """
       #EXTM3U


### PR DESCRIPTION
The spec specifies that this is a floating point value, but there seem to be streams that set this tag as an integer value(for example, the very first stream listed in https://ottverse.com/free-hls-m3u8-test-urls/)