### PR TITLE
Switch to using `data[:uri]` and `data[:byterange]` for field access

### DIFF
--- a/lib/hls/playlist/tag/map.ex
+++ b/lib/hls/playlist/tag/map.ex
@@ -19,8 +19,8 @@ defmodule HLS.Playlist.Tag.Map do
 
   def marshal_uri_and_byterange(data) do
     [
-      data.uri && "URI=\"#{data.uri}\"",
-      data.byterange && "BYTERANGE=\"#{Byterange.marshal(data.byterange)}\""
+      data[:uri] && "URI=\"#{data[:uri]}\"",
+      data[:byterange] && "BYTERANGE=\"#{Byterange.marshal(data[:byterange])}\""
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join(",")


### PR DESCRIPTION
If the keys don't exist, accessing them results in a `KeyError`:

```
** (KeyError) key :byterange not found in: %{uri: "muxed_header_video_track_part_0.mp4"}
    (kim_hls 0.1.0) lib/hls/playlist/tag/map.ex:23: HLS.Playlist.Tag.Map.marshal_uri_and_byterange/1
    (kim_hls 0.1.0) lib/hls/playlist/media.ex:85: anonymous fn/1 in HLS.Playlist.Marshaler.HLS.Playlist.Media.marshal/1
```